### PR TITLE
Add a customized JsonPath parser for OCL.

### DIFF
--- a/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/BaseImage.java
+++ b/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/BaseImage.java
@@ -1,0 +1,12 @@
+package org.eclipse.osc.services.ocl.loader;
+
+import lombok.Data;
+
+@Data
+public class BaseImage {
+
+    private String name;
+    private String type;
+    private BaseImageFilter filters;
+
+}

--- a/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/BaseImageFilter.java
+++ b/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/BaseImageFilter.java
@@ -1,0 +1,11 @@
+package org.eclipse.osc.services.ocl.loader;
+
+import lombok.Data;
+
+@Data
+public class BaseImageFilter {
+
+    private String name;
+    private String id;
+
+}

--- a/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/Image.java
+++ b/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/Image.java
@@ -13,30 +13,7 @@ public class Image {
 
 }
 
-@Data
-class Provisioner {
 
-    private String name;
-    private String type;
-    private List<String> environment_vars;
-    private List<String> inline;
 
-}
 
-@Data
-class BaseImageFilter {
 
-    private String name;
-    private String id;
-
-}
-
-@Data
-class BaseImage {
-
-    private String name;
-    private String ssh_user;
-    private String type;
-    private BaseImageFilter filters;
-
-}

--- a/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/Ocl.java
+++ b/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/Ocl.java
@@ -1,9 +1,16 @@
 package org.eclipse.osc.services.ocl.loader;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Data
 public class Ocl {
@@ -19,5 +26,44 @@ public class Ocl {
     private Network network;
     private List<Storage> storage;
     private Console console;
+
+    @JsonIgnore
+    public <T> T referTo(String jsonPath, Class<T> valueType) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+        if (!jsonPath.startsWith("$.")) {
+            System.out.println("Not a valid JsonPath.");
+            throw new IllegalAccessException(jsonPath + "is not a valid JsonPath.");
+        }
+
+        Matcher jsonPathMatter = Pattern.compile("([A-Za-z_0-9]+(?=[$\\.\\[\\]]{1}))").matcher(jsonPath);
+
+        List<String> matches = new ArrayList<String>();
+        while(jsonPathMatter.find()) {
+            matches.add(jsonPathMatter.group());
+        }
+
+        Object node = this;
+        for (String path: matches) {
+            if (path.equals("$")) {
+                continue;
+            }
+
+            try {
+                Integer index = Integer.parseInt(path);
+                Method getter = node.getClass().getDeclaredMethod("get", int.class);
+                node = getter.invoke(node, index);
+            } catch (NumberFormatException e){
+                Method getter = node.getClass().getDeclaredMethod(
+                        "get" + path.substring(0,1).toUpperCase(Locale.ROOT) + path.substring(1));
+                node = getter.invoke(node);
+            }
+        }
+
+        if (node.getClass() == valueType) {
+            return (T) node;
+        } else {
+            throw new IllegalAccessException("Not the same type. Please check your JsonPath.");
+        }
+    }
 
 }

--- a/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/Ocl.java
+++ b/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/Ocl.java
@@ -2,16 +2,18 @@ package org.eclipse.osc.services.ocl.loader;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
+import lombok.extern.java.Log;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+@Log
 @Data
 public class Ocl {
 
@@ -31,37 +33,34 @@ public class Ocl {
     public <T> T referTo(String jsonPath, Class<T> valueType) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
 
         if (!jsonPath.startsWith("$.")) {
-            System.out.println("Not a valid JsonPath.");
+            log.log(Level.WARNING, jsonPath + "is not a valid JsonPath.");
             throw new IllegalAccessException(jsonPath + "is not a valid JsonPath.");
         }
 
-        Matcher jsonPathMatter = Pattern.compile("([A-Za-z_0-9]+(?=[$\\.\\[\\]]{1}))").matcher(jsonPath);
+        Matcher matcher = Pattern.compile("([A-Za-z_0-9]+(?=[$\\.\\[\\]]{1}))").matcher(jsonPath);
 
-        List<String> matches = new ArrayList<String>();
-        while(jsonPathMatter.find()) {
-            matches.add(jsonPathMatter.group());
-        }
-
-        Object node = this;
-        for (String path: matches) {
-            if (path.equals("$")) {
+        Object object = this;
+        while(matcher.find()) {
+            String matchStr = matcher.group();
+            if (matchStr.equals("$")) {
                 continue;
             }
 
             try {
-                Integer index = Integer.parseInt(path);
-                Method getter = node.getClass().getDeclaredMethod("get", int.class);
-                node = getter.invoke(node, index);
+                Integer index = Integer.parseInt(matchStr);
+                Method getter = object.getClass().getDeclaredMethod("get", int.class);
+                object = getter.invoke(object, index);
             } catch (NumberFormatException e){
-                Method getter = node.getClass().getDeclaredMethod(
-                        "get" + path.substring(0,1).toUpperCase(Locale.ROOT) + path.substring(1));
-                node = getter.invoke(node);
+                Method getter = object.getClass().getDeclaredMethod("get" +
+                        matchStr.substring(0,1).toUpperCase(Locale.ROOT) + matchStr.substring(1));
+                object = getter.invoke(object);
             }
         }
 
-        if (node.getClass() == valueType) {
-            return (T) node;
+        if (object.getClass() == valueType) {
+            return (T) object;
         } else {
+            log.log(Level.WARNING, "Not the same type. Please check your JsonPath.");
             throw new IllegalAccessException("Not the same type. Please check your JsonPath.");
         }
     }

--- a/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/Provisioner.java
+++ b/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/Provisioner.java
@@ -1,0 +1,15 @@
+package org.eclipse.osc.services.ocl.loader;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class Provisioner {
+
+    private String name;
+    private String type;
+    private List<String> environment_vars;
+    private List<String> inline;
+
+}

--- a/services/ocl-loader/src/test/resources/test.json
+++ b/services/ocl-loader/src/test/resources/test.json
@@ -19,7 +19,8 @@
           "WORK_HOME=/usr1/KAFKA/"
         ],
         "inline": [
-          "cd ${WORK_HOME} && wget http://xxxx/kafka/release.jar"
+          "cd ${WORK_HOME} && wget http://xxxx/kafka/release.jar",
+          "echo $PATH"
         ]
       }
     ],
@@ -43,7 +44,7 @@
       {
         "name": "kafka_image",
         "base": "$.image.base[0]",
-        "provisioners": ["/image/provisioners/0"]
+        "provisioners": ["$.image.provisioners[0]"]
       }
     ]
   },


### PR DESCRIPTION
What this PR does / why we need it:

Add a customized `JsonPath` parser for OCL.
Align the basic classes to OCL.

Which issue this PR fixes:
Resolves #26  resolves #18 