### PR TITLE
Bugfix: fix the equals and hashCode method of data object when they extended a base data object

### DIFF
--- a/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/Artifact.java
+++ b/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/Artifact.java
@@ -1,10 +1,12 @@
 package org.eclipse.osc.services.ocl.loader;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.List;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class Artifact extends RuntimeBase {
 
     private String name;

--- a/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/Security.java
+++ b/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/Security.java
@@ -1,10 +1,12 @@
 package org.eclipse.osc.services.ocl.loader;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.List;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class Security extends RuntimeBase {
 
     private String name;

--- a/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/SecurityRule.java
+++ b/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/SecurityRule.java
@@ -1,8 +1,10 @@
 package org.eclipse.osc.services.ocl.loader;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class SecurityRule extends RuntimeBase {
 
     private String name;

--- a/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/Storage.java
+++ b/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/Storage.java
@@ -1,8 +1,10 @@
 package org.eclipse.osc.services.ocl.loader;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class Storage extends RuntimeBase {
 
     private String name;

--- a/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/Subnet.java
+++ b/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/Subnet.java
@@ -1,8 +1,10 @@
 package org.eclipse.osc.services.ocl.loader;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class Subnet extends RuntimeBase {
 
     private String vpc;

--- a/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/VM.java
+++ b/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/VM.java
@@ -1,10 +1,12 @@
 package org.eclipse.osc.services.ocl.loader;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.List;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class VM extends RuntimeBase {
 
     private String name;

--- a/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/VPC.java
+++ b/services/ocl-loader/src/main/java/org/eclipse/osc/services/ocl/loader/VPC.java
@@ -1,8 +1,10 @@
 package org.eclipse.osc.services.ocl.loader;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class VPC extends RuntimeBase {
 
     private String name;

--- a/services/ocl-loader/src/test/java/org/eclipse/osc/services/ocl/loader/StorageTest.java
+++ b/services/ocl-loader/src/test/java/org/eclipse/osc/services/ocl/loader/StorageTest.java
@@ -14,6 +14,7 @@ public class StorageTest {
         storage.setName("sameName");
         anotherStorage.setName("sameName");
         Assertions.assertNotEquals(storage, anotherStorage);
+        Assertions.assertNotEquals(storage.hashCode(), anotherStorage.hashCode());
     }
 
 }

--- a/services/ocl-loader/src/test/java/org/eclipse/osc/services/ocl/loader/StorageTest.java
+++ b/services/ocl-loader/src/test/java/org/eclipse/osc/services/ocl/loader/StorageTest.java
@@ -1,0 +1,19 @@
+package org.eclipse.osc.services.ocl.loader;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class StorageTest {
+
+    @Test
+    public void testEquals() {
+        Storage storage = new Storage();
+        Storage anotherStorage = new Storage();
+        storage.setState("some state");
+        anotherStorage.setState("another state");
+        storage.setName("sameName");
+        anotherStorage.setName("sameName");
+        Assertions.assertNotEquals(storage, anotherStorage);
+    }
+
+}


### PR DESCRIPTION
The previous Data Object's equals and hashcode code generation have bugs, it doesn't call super() so two object will be equals even the property inherited from super is not equals. 

For example:
<code>
@Data
public class Storage extends RuntimeBase {
    private String name;
    private String type;
    private String size;
}
</code>

will have the wrong behavior:


        Storage storage = new Storage();
        Storage anotherStorage = new Storage();
        storage.setState("some state");
        anotherStorage.setState("another state");
        storage.setName("sameName");
        anotherStorage.setName("sameName");
        Assertions.Equals(storage, anotherStorage); //this line return true and the test can pass, which is wrong. 