### PR TITLE
add config to suppress warnings

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -37,6 +37,12 @@
         <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
     </module>
 
+    <module name="SuppressWithPlainTextCommentFilter">
+        <property name="offCommentFormat" value="CHECKSTYLE OFF\: ([\w\|]+)"/>
+        <property name="onCommentFormat" value="CHECKSTYLE ON\: ([\w\|]+)"/>
+        <property name="checkFormat" value="$1"/>
+    </module>
+
     <module name="TreeWalker">
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
@@ -365,7 +371,7 @@
         </module>
     </module>
     <module name="RegexpHeader">
-        <property name="headerFile" value="license.header"/>
+        <property name="headerFile" value="${checkstyle.header.file}"/>
         <property name="multiLines" value="1,2"/>
     </module>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,7 @@
                 <version>${checkstyle-maven-plugin.version}</version>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
+                    <headerLocation>license.header</headerLocation>
                     <failsOnError>true</failsOnError>
                     <violationSeverity>warning</violationSeverity>
                 </configuration>
@@ -188,14 +189,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <version>1.6</version>
-                <configuration>
-                    <!-- your own config goes here -->
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
1. Allow suppressing warnings by adding inline comments. 
2. remove wrong license plugin
3. Move license  header file  as config to plugin. This will allow maven sub modules to also validate header files. 